### PR TITLE
Fix header navigation links

### DIFF
--- a/app/components/HeaderNav.vue
+++ b/app/components/HeaderNav.vue
@@ -4,11 +4,11 @@
     Logo
     <nav aria-label="Main Navigation">
       <ul role="menu">
-        <li><a href="/">Home</a></li>
-        <li><a href="/about">About</a></li>
-        <li><a href="/portfolio">Portfolio</a></li>
-        <li><a href="/blog">Blog</a></li>
-        <li><a href="/contact">Contact</a></li>
+        <li><NuxtLink to="/">Home</NuxtLink></li>
+        <li><NuxtLink to="/about">About</NuxtLink></li>
+        <li><NuxtLink to="/portfolio">Portfolio</NuxtLink></li>
+        <li><NuxtLink to="/blog">Blog</NuxtLink></li>
+        <li><NuxtLink to="/contact">Contact</NuxtLink></li>
       </ul>
     </nav>
     <ThemeToggle />


### PR DESCRIPTION
_Testing out this whole openai codex thing_

## Summary
- use `<NuxtLink>` for all internal navigation links

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498f532ba88329bd861fd3241d76e6